### PR TITLE
Fix typo 'acceptible'

### DIFF
--- a/ex2/include/boost1.49_min/boost/type_traits/detail/is_function_ptr_tester.hpp
+++ b/ex2/include/boost1.49_min/boost/type_traits/detail/is_function_ptr_tester.hpp
@@ -26,7 +26,7 @@
 namespace boost {
 namespace type_traits {
 
-// Note it is acceptible to use ellipsis here, since the argument will
+// Note it is acceptable to use ellipsis here, since the argument will
 // always be a pointer type of some sort (JM 2005/06/04):
 no_type BOOST_TT_DECL is_function_ptr_tester(...);
 


### PR DESCRIPTION

Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'acceptable', you typed 'acceptible'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

If you decide to close this pull request, pleace specify why before doing so.

With kind regards,
TheTypoMaster
            